### PR TITLE
Require generator's autoloader

### DIFF
--- a/application.php
+++ b/application.php
@@ -1,9 +1,9 @@
 <?php
 
+require __DIR__ . "/vendor/autoload.php";
+
 use Keboola\AppSkeleton\GenerateCommand;
 use Symfony\Component\Console\Application;
-
-require "vendor/autoload.php";
 
 try {
     $application = new Application();


### PR DESCRIPTION
Prevents generator from requiring autoloader from workdir, which is actually the project's dir. 