### PR TITLE
php-component - image name is not required for dev

### DIFF
--- a/templates/php-component/docker-compose.yml
+++ b/templates/php-component/docker-compose.yml
@@ -2,7 +2,6 @@ version: '2'
 services:
   dev:
     build: .
-    image: keboola/my-component
     volumes:
       - ./:/code
       - ./data:/data


### PR DESCRIPTION
Image name is useless for development and unnecessarily forces developer to change it after component is generated.