### PR TITLE
APP_IMAGE as internal variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ Setup of travis deployment does the following:
 
 - enable building of the repository
 - build only if .travis.yml is present
-- set `APP_IMAGE` variable
 - set `KBC_DEVELOPERPORTAL_VENDOR` variable
 - set `KBC_DEVELOPERPORTAL_APP` variable
 - set `KBC_DEVELOPERPORTAL_USERNAME` variable

--- a/src/GenerateCommand.php
+++ b/src/GenerateCommand.php
@@ -137,7 +137,6 @@ class GenerateCommand extends Command
         $process->mustRun();
         ProcessDecorator::run("travis enable -r " . escapeshellarg($repository), $output);
         ProcessDecorator::run("travis settings builds_only_with_travis_yml --enable", $output);
-        ProcessDecorator::run("travis env set APP_IMAGE my-component --public", $output);
 
         $question = new Question('Please enter <info>vendor id</info>: ');
         $vendor = $helper->ask($input, $output, $question);

--- a/templates-common/.travis.yml
+++ b/templates-common/.travis.yml
@@ -3,7 +3,8 @@ language: bash
 services:
   - docker
 before_script:
-  - docker build . --tag=my-component
+  - export APP_IMAGE=keboola-component
+  - docker build . --tag=$APP_IMAGE
 after_success:
   - docker images
 deploy:

--- a/templates/bitbucket-deploy/bitbucket-pipelines.yml
+++ b/templates/bitbucket-deploy/bitbucket-pipelines.yml
@@ -4,14 +4,16 @@ options:
 pipelines:
   default:
     - step:
-        script: 
-          - docker build . --tag=my-component
+        script:
+          - export APP_IMAGE=keboola-component
+          - docker build . --tag=$APP_IMAGE
           - docker images
 
   tags:
     '*':
       - step:
           script:
-          - docker build . --tag=my-component
+          - export APP_IMAGE=keboola-component
+          - docker build . --tag=$APP_IMAGE
           - docker images
           - ./deploy.sh

--- a/templates/gitlab-deploy/.gitlab-ci.yml
+++ b/templates/gitlab-deploy/.gitlab-ci.yml
@@ -2,7 +2,7 @@ image: docker:latest
 
 variables:
   DOCKER_DRIVER: overlay2
-  APP_IMAGE: my-component
+  APP_IMAGE: keboola-component
 
 services:
 - docker:dind

--- a/templates/php-component/.travis.yml
+++ b/templates/php-component/.travis.yml
@@ -6,6 +6,7 @@ services:
   - docker
 
 before_script:
+  - export APP_IMAGE=keboola-component
   - docker -v
   - docker build -t $APP_IMAGE .
   - docker run $APP_IMAGE composer ci

--- a/templates/python-tests/.travis.yml
+++ b/templates/python-tests/.travis.yml
@@ -6,9 +6,9 @@ services:
 before_script:
   - export APP_IMAGE=keboola-component
   - docker -v
-  - docker build -t my-component .
-  - docker run my-component flake8
-  - docker run my-component python -m unittest discover
+  - docker build -t $APP_IMAGE .
+  - docker run $APP_IMAGE flake8
+  - docker run $APP_IMAGE python -m unittest discover
   # push test image to ECR
   - docker pull quay.io/keboola/developer-portal-cli-v2:latest
   - export REPOSITORY=`docker run --rm -e KBC_DEVELOPERPORTAL_USERNAME -e KBC_DEVELOPERPORTAL_PASSWORD -e KBC_DEVELOPERPORTAL_URL quay.io/keboola/developer-portal-cli-v2:latest ecr:get-repository $KBC_DEVELOPERPORTAL_VENDOR $KBC_DEVELOPERPORTAL_APP`

--- a/templates/python-tests/.travis.yml
+++ b/templates/python-tests/.travis.yml
@@ -4,6 +4,7 @@ services:
   - docker
 
 before_script:
+  - export APP_IMAGE=keboola-component
   - docker -v
   - docker build -t my-component .
   - docker run my-component flake8

--- a/templates/r-tests/.travis.yml
+++ b/templates/r-tests/.travis.yml
@@ -4,8 +4,9 @@ services:
   - docker
 
 before_script:
-  - docker build . --tag=my-component
-  - docker run -e KBC_DATADIR=/code/tests/data/ my-component /code/tests/tests.sh
+  - export APP_IMAGE=keboola-component
+  - docker build . --tag=$APP_IMAGE
+  - docker run -e KBC_DATADIR=/code/tests/data/ $APP_IMAGE /code/tests/tests.sh
 after_success:
   - docker images
 deploy:


### PR DESCRIPTION
`APP_IMAGE` doesn't have to be defined as ENV variable since it is used only internally. It doesn't have any side effects outside of build like image name etc. 

Alternatively this can be fixed by changing default value to something like `keboola-component`. Current `my-component` looks like a placeholder which should be changed.

- [x] upravit v `templates\r-tests\.travis.yml`
- [x] doplnit do `templates\bitbucket-deploy\bitbucket-pipelines.yml`
- [x] doplnit do `templates-common\.travis.yml`