### PR TITLE
feat: initialize utf8 locale by default

### DIFF
--- a/templates/php-component/Dockerfile
+++ b/templates/php-component/Dockerfile
@@ -12,10 +12,17 @@ COPY docker/composer-install.sh /tmp/composer-install.sh
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         git \
+        locales \
         unzip \
 	&& rm -r /var/lib/apt/lists/* \
+	&& sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen \
+	&& locale-gen \
 	&& chmod +x /tmp/composer-install.sh \
 	&& /tmp/composer-install.sh
+
+ENV LANGUAGE=en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
 
 ## Composer - deps always cached unless changed
 # First copy only composer files

--- a/templates/php-component/src/Config.php
+++ b/templates/php-component/src/Config.php
@@ -9,7 +9,7 @@ use Keboola\Component\Config\BaseConfig;
 class Config extends BaseConfig
 {
     // @todo implement your custom getters
-    public function getFoo() : string
+    public function getFoo(): string
     {
         return $this->getValue(['parameters', 'foo']);
     }


### PR DESCRIPTION
follow up to: https://github.com/keboola/processor-skip-lines/pull/18 

problem https://github.com/keboola/processor-skip-lines/issues/16 se potencionalne tyka vsech processoru a vsech dumb extractoru (ktery soubory nijak nezpracovavaji a nazvy berou as is) a tak si rikam, je nejakej duvod, proc by to nemelo byt vsude?