### PR TITLE
Ignore composer.lock inside templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.idea
 /vendor
 /composer.phar
+/templates/**/composer.lock


### PR DESCRIPTION
This needs to be implemented on the top level as inside the components users will want to commit composer.lock. 