### PR TITLE
Lock PHP in Dockerfile in php-component template

### DIFF
--- a/templates/php-component/Dockerfile
+++ b/templates/php-component/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7-cli
+FROM php:7.4-cli
 
 ARG COMPOSER_FLAGS="--prefer-dist --no-interaction"
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Changes:
- PHP version in Dockerfile locked `FROM php:7-cli` -> `FROM php:7.4-cli` in `php-component` template
- It solves issue if user has locally outdated version of `php:7-cli` eg. PHP `7.3` and it fails, because in `composer.json` is PHP locked to `7.4`