### PR TITLE
Updated version from 2 to 3 in docker-compose.yml

### DIFF
--- a/templates/php-component/Dockerfile
+++ b/templates/php-component/Dockerfile
@@ -27,11 +27,14 @@ ENV LC_ALL=en_US.UTF-8
 ## Composer - deps always cached unless changed
 # First copy only composer files
 COPY composer.* /code/
+
 # Download dependencies, but don't run scripts or init autoloaders as the app is missing
 RUN composer install $COMPOSER_FLAGS --no-scripts --no-autoloader
-# copy rest of the app
+
+# Copy rest of the app
 COPY . /code/
-# run normal composer - all deps are cached already
+
+# Run normal composer - all deps are cached already
 RUN composer install $COMPOSER_FLAGS
 
 CMD ["php", "/code/src/run.php"]

--- a/templates/php-component/docker-compose.yml
+++ b/templates/php-component/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 services:
   dev:
     build: .


### PR DESCRIPTION
Changes:
- Updated `version`  from  `2` to  `3` in `docker-compose.yml`
- Version in `docker-compose.yml` determines (among other things) what version of the Docker API will be used
- If older version of Docker API, Docker throws an error for some operations