### PR TITLE
Add common exceptions to php-component template

### DIFF
--- a/templates/php-component/composer.json
+++ b/templates/php-component/composer.json
@@ -4,7 +4,8 @@
     "license": "MIT",
     "require": {
         "php": "^7.4",
-        "keboola/php-component": "^8.1"
+        "keboola/php-component": "^8.1",
+        "keboola/common-exceptions": "^1.1"
     },
     "require-dev": {
         "php-parallel-lint/php-parallel-lint": "^1.2",

--- a/templates/php-component/src/run.php
+++ b/templates/php-component/src/run.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-use Keboola\Component\UserException;
 use Keboola\Component\Logger;
+use Keboola\CommonExceptions\UserExceptionInterface;
 use MyComponent\Component;
 
 require __DIR__ . '/../vendor/autoload.php';
@@ -13,10 +13,10 @@ try {
     $app = new Component($logger);
     $app->execute();
     exit(0);
-} catch (UserException $e) {
+} catch (UserExceptionInterface $e) {
     $logger->error($e->getMessage());
     exit(1);
-} catch (\Throwable $e) {
+} catch (Throwable $e) {
     $logger->critical(
         get_class($e) . ':' . $e->getMessage(),
         [


### PR DESCRIPTION
WAITING FOR: https://github.com/keboola/component-generator/pull/82

Changes:
- Use `UserExceptionInterface` instead of `UserException` in `php-template` in `run.php`.