### PR TITLE
Template fix 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,0 @@
-version: "3"
-services:
-  dev:
-    build: .
-    image: keboola/component-generator

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,5 @@
+version: "3"
+services:
+  dev:
+    build: .
+    image: keboola/component-generator

--- a/templates/php-component/src/run.php
+++ b/templates/php-component/src/run.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-use Keboola\Component\UserException;
 use Keboola\Component\Logger;
+use Keboola\Component\UserException;
 use MyComponent\Component;
 
 require __DIR__ . '/../vendor/autoload.php';
@@ -16,7 +16,7 @@ try {
 } catch (UserException $e) {
     $logger->error($e->getMessage());
     exit(1);
-} catch (\Throwable $e) {
+} catch (Throwable $e) {
     $logger->critical(
         get_class($e) . ':' . $e->getMessage(),
         [


### PR DESCRIPTION
Build nový komponenty házel na PHPCS chybu, že namespace mají být podle abecedy a že Throwable se nemá volat s "\\".
